### PR TITLE
Add AWSCNIPrefixDelegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add AWSCNIPrefixDelegation annotation.
+
 ## [0.5.0] - 2021-11-11
 
 ### Added

--- a/pkg/annotation/aws.go
+++ b/pkg/annotation/aws.go
@@ -15,6 +15,15 @@ const AWSCNIMinimumIPTarget = "alpha.cni.aws.giantswarm.io/minimum-ip-target"
 // support:
 //   - crd: awsclusters.infrastructure.giantswarm.io
 //     apiversion: v1alpha2
+//     release: Since 16.1.0
+// documentation:
+//   This annotation allows configuration of the ENABLE_PREFIX_DELEGATION parameter for AWS CNI.
+//   See [Enable Prefix Delegation](https://github.com/aws/amazon-vpc-cni-k8s#enable_prefix_delegation-v190)
+const AWSCNIPrefixDelegation = "alpha.cni.aws.giantswarm.io/prefix-delegation"
+
+// support:
+//   - crd: awsclusters.infrastructure.giantswarm.io
+//     apiversion: v1alpha2
 //     release: Since 14.0.0
 // documentation:
 //   This annotation allows configuration of the WARM_IP_TARGET parameter for AWS CNI.


### PR DESCRIPTION
This allows customers enabling the prefix delegation for AWS CNI which will be introduced within AWS release v16.1.
Enabling this feature will improve the speed of IP assignment on nitro based instances.

See https://github.com/aws/amazon-vpc-cni-k8s#enable_prefix_delegation-v190

Addresses: https://github.com/giantswarm/roadmap/issues/396