### PR TITLE
Fix cluster-apps-operator watching label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Move `ClusterAppsOperatorWatching` to `label` package instead of `annotation` as intended.
+
 ## [0.7.0] - 2021-12-08
 
 ### Added

--- a/pkg/annotation/app.go
+++ b/pkg/annotation/app.go
@@ -37,7 +37,3 @@ const AppOwners = "application.giantswarm.io/owners"
 // AppTeam annotation is defined in Chart.yaml and added to AppCatalogEntry CRs.
 // It is used when an app is owned by a single team.
 const AppTeam = "application.giantswarm.io/team"
-
-// ClusterAppsOperatorWatching is the label which should be added to Cluster CRs to indicate
-// that cluster-apps-operator should watch it.
-const ClusterAppsOperatorWatching = "cluster-apps-operator.giantswarm.io/watching"

--- a/pkg/label/app.go
+++ b/pkg/label/app.go
@@ -3,3 +3,7 @@ package label
 // AppOperatorWatching is the label added to configmaps by app-operator when
 // it is watching for values changes.
 const AppOperatorWatching = "app-operator.giantswarm.io/watching"
+
+// ClusterAppsOperatorWatching is the label which should be added to Cluster CRs to indicate
+// that cluster-apps-operator should watch it.
+const ClusterAppsOperatorWatching = "cluster-apps-operator.giantswarm.io/watching"


### PR DESCRIPTION
Somehow I missed that I put it in the `annotation` package instead of `label`.