### PR TITLE
Add AppName annotation for chart CR watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `AppName` annotation for use by chart CR watcher in app-operator.
+
 ## [0.7.1] - 2021-12-08
 
 ### Fixed

--- a/pkg/annotation/app.go
+++ b/pkg/annotation/app.go
@@ -3,6 +3,10 @@ package annotation
 // Metadata annotation stores an app metadata URL from the appCatalog's index.yaml.
 const AppMetadata = "application.giantswarm.io/metadata"
 
+// AppName annotation is used by the chart status watcher to find the
+// app CR for each chart CR.
+const AppName = "chart-operator.giantswarm.io/app-name"
+
 // AppNamespace annotation is used by the chart status watcher to find the
 // app CR for chart CRs which are always in the giantswarm namespace.
 const AppNamespace = "chart-operator.giantswarm.io/app-namespace"


### PR DESCRIPTION
Towards giantswarm/giantswarm#20331

This annotation is added to chart CRs for use in the chart CR watcher in app-operator.
So when the chart CR status changes we update the status for the correct app CR.

