### PR TITLE
Allow to use internal elb for node pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `alpha.giantswarm.io/internal-elb` annotation.
+
 ## [0.10.1] - 2022-03-21
 
 ### Fixed

--- a/pkg/annotation/aws.go
+++ b/pkg/annotation/aws.go
@@ -116,6 +116,6 @@ const AWSSubnetSize = "alpha.aws.giantswarm.io/aws-subnet-size"
 //     release: Since 17.3.2
 // documentation:
 //   This annotation is used to support internal load balancers.
-// 	 It will set a tag on the subnet of AWSMachineDeployment.
+//   It will set a tag on the subnet of AWSMachineDeployment.
 //   See [Subnet Discovery](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/deploy/subnet_discovery.md#private-subnets)
 const AWSInternalELB = "alpha.aws.giantswarm.io/internal-elb"

--- a/pkg/annotation/aws.go
+++ b/pkg/annotation/aws.go
@@ -109,3 +109,13 @@ const AWSMetadataV2 = "alpha.aws.giantswarm.io/metadata-v2"
 //   This annotation is used for configuring the subnet size of AWSCluster or AWSMachineDeployment.
 //   The value is a number that will represent the subnet mask used when creating the subnet. This value must be smaller than 28 due to AWS restrictions.
 const AWSSubnetSize = "alpha.aws.giantswarm.io/aws-subnet-size"
+
+// support:
+//   - crd: awsmachinedeployments.infrastructure.giantswarm.io
+//     apiversion: v1alpha3
+//     release: Since 17.3.2
+// documentation:
+//   This annotation is used to support internal load balancers.
+// 	 It will set a tag on the subnet of AWSMachineDeployment.
+//   See [Subnet Discovery](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/deploy/subnet_discovery.md#private-subnets)
+const AWSInternalELB = "alpha.aws.giantswarm.io/internal-elb"


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/21945

When adding the annotation to AWSMachineDeployment CR the usage of internal ELB's or NLB's will be allowed.