### PR TITLE
Add `cilium.giantswarm.io/force-disable-cilium-kube-proxy` annotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cilium.giantswarm.io/force-disable-cilium-kube-proxy` annotation.
+
 ## [0.13.0] - 2022-09-20
 
 ## Added

--- a/pkg/annotation/cilium.go
+++ b/pkg/annotation/cilium.go
@@ -6,6 +6,12 @@ package annotation
 //   - crd: awsclusters.infrastructure.giantswarm.io
 //     apiversion: v1alpha3
 //     release: Since 18.0.0
+//
 // documentation:
-//   This annotation allows specifying a CIDR to be used by cilium during cluster upgrades from v17 to v18.
+//
+//	This annotation allows specifying a CIDR to be used by cilium during cluster upgrades from v17 to v18.
 const CiliumPodCidr = "cilium.giantswarm.io/pod-cidr"
+
+// Not documented as it's not meant for customers.
+// This annotation allows disabling Cilium's kube proxy implementation.
+const CiliumForceDisableKubeProxyAnnotation = "cilium.giantswarm.io/force-disable-cilium-kube-proxy"


### PR DESCRIPTION
New annotation needed to migrate from aws-cni to cilium