### PR TITLE
Add resolver rules owner account annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `aws.giantswarm.io/resolver-rules-owner-account` annotation.
+
 ## [0.18.0] - 2023-01-13
 
 ### Added

--- a/pkg/annotation/capa.go
+++ b/pkg/annotation/capa.go
@@ -37,3 +37,7 @@ const NetworkTopologyTransitGatewayIDAnnotation = "network-topology.giantswarm.i
 // NetworkTopologyPrefixListIDAnnotation contains the ID of the Prefix List containing the CIDRs of all clusters.
 // This is either the user-provided PL ID or the one created by this operator.
 const NetworkTopologyPrefixListIDAnnotation = "network-topology.giantswarm.io/prefix-list"
+
+// ResolverRulesOwnerAWSAccountId contains the AWS Account ID that owns the resolver rules that need to be associated
+// with the workload cluster VPC.
+const ResolverRulesOwnerAWSAccountId = "aws.giantswarm.io/resolver-rules-owner-account"


### PR DESCRIPTION
The `dns-operator-aws` associates resolver rules with workload clusters VPCs. To know which resolver rules need to be associated, we pass the owner AWS account id as a parameter to the `dns-operator-aws`, and filter resolver rules owned by that account. 

In this PR I'm adding a new annotation that will replace the need to pass the AWS account id as a parameter to the operator. Instead, the operator will read this annotation from the `AWSCluster`. CRs that don't have this annotation won't get resolver rules associated with its vpc.