### PR TITLE
Add flatcar alpha channel annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+
+- Add `alpha.flatcar.giantswarm.io/release-version` annotation to support flatcar alpha channel releases.
+
 ## [0.21.0] - 2023-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
-- Add `alpha.flatcar.giantswarm.io/release-version` annotation to support flatcar alpha channel releases.
+- Add `alpha.giantswarm.io/flatcar-release-version` annotation to support flatcar alpha channel releases.
 
 ## [0.21.0] - 2023-06-12
 

--- a/pkg/annotation/flatcar.go
+++ b/pkg/annotation/flatcar.go
@@ -7,5 +7,5 @@ package annotation
 //
 // documentation:
 //
-//	This annotation is used for configuring flatcar alpha channel release version.
-const FlatcarAlphaReleaseVersion = "alpha.flatcar.giantswarm.io/release-version"
+//	This annotation is used for selecting a specific flatcar release version for machine deployments.
+const FlatcarReleaseVersion = "alpha.flatcar.giantswarm.io/release-version"

--- a/pkg/annotation/flatcar.go
+++ b/pkg/annotation/flatcar.go
@@ -1,0 +1,11 @@
+package annotation
+
+// support:
+//   - crd: awsmachinedeployments.infrastructure.giantswarm.io
+//     apiversion: v1alpha3
+//     release: Since 19.1.0
+//
+// documentation:
+//
+//	This annotation is used for configuring flatcar alpha channel release version.
+const FlatcarAlphaReleaseVersion = "alpha.flatcar.giantswarm.io/release-version"

--- a/pkg/annotation/flatcar.go
+++ b/pkg/annotation/flatcar.go
@@ -8,4 +8,4 @@ package annotation
 // documentation:
 //
 //	This annotation is used for selecting a specific flatcar release version for machine deployments.
-const FlatcarReleaseVersion = "alpha.flatcar.giantswarm.io/release-version"
+const FlatcarReleaseVersion = "alpha.giantswarm.io/flatcar-release-version"


### PR DESCRIPTION
This PR provide a new annotation supporting flatcar alpha channel release for AWSMachineDeployments.